### PR TITLE
gh-117084: Fix zip extraction bug

### DIFF
--- a/Lib/zipfile/__init__.py
+++ b/Lib/zipfile/__init__.py
@@ -605,7 +605,7 @@ class ZipInfo:
 
     def is_dir(self):
         """Return True if this archive member is a directory."""
-        return self.filename.endswith('/')
+        return self.filename.endswith('/') or self.filename.endswith('\\')
 
 
 # ZIP encryption uses the CRC32 one-byte primitive for scrambling some

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
@@ -1,0 +1,1 @@
+Fix extraction of  ZIP files created on windows

--- a/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
+++ b/Misc/NEWS.d/next/Core and Builtins/2024-03-20-15-54-25.gh-issue-117084.uj1NbR.rst
@@ -1,1 +1,1 @@
-Fix extraction of  ZIP files created on windows
+Fix extraction of zip files created on Windows


### PR DESCRIPTION
On Windows a directory is ending in \\ and not /.

This is the smallest fix i could think of. 
Not sure if there are edge cases with files containing `\\` at the end.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
gh-NNNNN: Summary of the changes made
```

Where: gh-NNNNN refers to the GitHub issue number.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `main`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `main`.

-->
